### PR TITLE
support rpc port override via env SWITCH_SAI_THRIFT_RPC_SERVER_PORT

### DIFF
--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -41,7 +41,6 @@ from sai_utils import *
 import sai_thrift.sai_adapter as adapter
 
 ROUTER_MAC = '00:77:66:55:44:00'
-THRIFT_PORT = 9092
 
 SKIP_TEST_NO_RESOURCES_MSG = 'Not enough resources to run test'
 PLATFORM = os.environ.get('PLATFORM')
@@ -113,7 +112,11 @@ class ThriftInterface(BaseTest):
         else:
             server = 'localhost'
 
-        self.transport = TSocket.TSocket(server, THRIFT_PORT)
+        server_port = get_thrift_server_port()
+
+        print("\nEstablishing Rpc connection to %s:%s\n" % (server, server_port))
+
+        self.transport = TSocket.TSocket(server, server_port)
         self.transport = TTransport.TBufferedTransport(self.transport)
         self.protocol = TBinaryProtocol.TBinaryProtocol(self.transport)
 
@@ -1005,7 +1008,14 @@ class MinimalPortVlanConfig(SaiHelperBase):
 
         super(MinimalPortVlanConfig, self).tearDown()
 
+def get_thrift_server_port():
+    if 'SWITCH_SAI_THRIFT_RPC_SERVER_PORT' in os.environ:
+        server_port = os.environ.get('SWITCH_SAI_THRIFT_RPC_SERVER_PORT')
+    else:
+        server_port = 9092
 
+    return server_port
+        
 def get_platform():
     """
     Get the platform token.

--- a/test/saithriftv2/Makefile
+++ b/test/saithriftv2/Makefile
@@ -17,6 +17,8 @@ CPPFLAGS = -I$(SAI_HEADER_DIR) -I. -std=c++11
 
 CPPFLAGS += -O0 -ggdb
 
+SWITCH_SAI_THRIFT_RPC_SERVER_PORT?=9092
+RPC_PORT_FLAGS = -DSWITCH_SAI_THRIFT_RPC_SERVER_PORT=$(SWITCH_SAI_THRIFT_RPC_SERVER_PORT)
 
 # specify add'l libraries along with libsai
 SAIRPC_EXTRA_LIBS?=
@@ -91,7 +93,7 @@ $(ODIR)/sai_rpc_server.o: ../../meta/sai_rpc_frontend.cpp
 	$(CXX) $(CPPFLAGS) -c $^ -o $@ $(CPPFLAGS) -I./gen-cpp -I../../meta -I../../inc -I../../experimental
 
 $(ODIR)/saiserver.o: src/saiserver.cpp $(CPP_SOURCES) directories
-	$(CXX) $(CPPFLAGS) -c src/saiserver.cpp  -o $@ $(CPPFLAGS) $(CDEFS) -I./gen-cpp -I../../inc -I../../experimental
+	$(CXX) $(CPPFLAGS) -c src/saiserver.cpp  -o $@ $(RPC_PORT_FLAGS) $(CPPFLAGS) $(CDEFS) -I./gen-cpp -I../../inc -I../../experimental
 
 $(ODIR)/librpcserver.a: $(ODIR)/sai_rpc.o $(ODIR)/sai_types.o $(ODIR)/sai_rpc_server.o
 	ar rcs $(ODIR)/librpcserver.a $^

--- a/test/saithriftv2/src/saiserver.cpp
+++ b/test/saithriftv2/src/saiserver.cpp
@@ -30,9 +30,6 @@ extern "C" {
 #include "switch_sai_rpc_server.h"
 }
 
-
-#define SWITCH_SAI_THRIFT_RPC_SERVER_PORT 9092
-
 sai_switch_api_t* sai_switch_api;
 
 std::map<std::string, std::string> gProfileMap;


### PR DESCRIPTION
the Makefile drives the port for the saiserver.cpp compile (default is still 9092)
sai_base_test.py will check the os environ for an override to 9092